### PR TITLE
インベントリの「クラフト」を削除

### DIFF
--- a/assets/minecraft/lang/en_us.json
+++ b/assets/minecraft/lang/en_us.json
@@ -1,0 +1,3 @@
+{
+    "container.crafting": " "
+}

--- a/assets/minecraft/lang/ja_jp.json
+++ b/assets/minecraft/lang/ja_jp.json
@@ -1,0 +1,3 @@
+{
+    "container.crafting": " "
+}


### PR DESCRIPTION
日本語とデフォルトである英語の両方に対応